### PR TITLE
[GH-2068]

### DIFF
--- a/webapp/src/components/content/textElement.test.tsx
+++ b/webapp/src/components/content/textElement.test.tsx
@@ -9,6 +9,8 @@ import '@testing-library/jest-dom'
 
 import {mocked} from 'jest-mock'
 
+import {CardDetailProvider} from '../cardDetail/cardDetailContext'
+
 import {TextBlock} from '../../blocks/textBlock'
 
 import {mockDOM, wrapDNDIntl, mockStateStore} from '../../testUtils'
@@ -45,6 +47,7 @@ describe('components/content/TextElement', () => {
     })
 
     const board1 = TestBlockFactory.createBoard()
+    const card = TestBlockFactory.createCard(board1)
     board1.id = 'board-id-1'
 
     const state = {
@@ -72,10 +75,12 @@ describe('components/content/TextElement', () => {
     test('return a textElement', async () => {
         const component = wrapDNDIntl(
             <ReduxProvider store={store}>
-                <TextElement
-                    block={defaultBlock}
-                    readonly={false}
-                />
+                <CardDetailProvider card={card}>
+                    <TextElement
+                        block={defaultBlock}
+                        readonly={false}
+                    />
+                </CardDetailProvider>
             </ReduxProvider>,
         )
 

--- a/webapp/src/components/content/textElement.tsx
+++ b/webapp/src/components/content/textElement.tsx
@@ -3,6 +3,8 @@
 import React from 'react'
 import {useIntl} from 'react-intl'
 
+import {useCardDetailContext} from '../cardDetail/cardDetailContext'
+
 import {ContentBlock} from '../../blocks/contentBlock'
 import {createTextBlock} from '../../blocks/textBlock'
 import mutator from '../../mutator'
@@ -19,6 +21,7 @@ type Props = {
 const TextElement = (props: Props): JSX.Element => {
     const {block, readonly} = props
     const intl = useIntl()
+    const {lastAddedBlock} = useCardDetailContext()
 
     return (
         <MarkdownEditor
@@ -30,6 +33,7 @@ const TextElement = (props: Props): JSX.Element => {
                 }
             }}
             readonly={readonly}
+            focus={lastAddedBlock.id === block.id}
         />
     )
 }

--- a/webapp/src/components/markdownEditor.tsx
+++ b/webapp/src/components/markdownEditor.tsx
@@ -13,6 +13,7 @@ type Props = {
     placeholderText?: string
     className?: string
     readonly?: boolean
+    focus?: boolean
 
     onChange?: (text: string) => void
     onFocus?: () => void
@@ -20,8 +21,8 @@ type Props = {
 }
 
 const MarkdownEditor = (props: Props): JSX.Element => {
-    const {placeholderText, onFocus, onBlur, onChange, text, id} = props
-    const [isEditing, setIsEditing] = useState(false)
+    const {placeholderText, onFocus, onBlur, onChange, text, id, focus = false} = props
+    const [isEditing, setIsEditing] = useState(focus)
     const html: string = Utils.htmlFromMarkdown(text || placeholderText || '')
 
     const previewElement = (


### PR DESCRIPTION
#### Summary

When adding a text block in a card it enters edit-mode straight away instead of having to click on it. 

#### Ticket Link

Fixes https://github.com/mattermost/focalboard/issues/2068
